### PR TITLE
Fix travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 
 
-[![Build Status](https://travis-ci.org/ONSdigital/sdc-rabbit-python.svg?branch=master)](https://www.codacy.com/app/ons-sdc/sdc-rabbit-python?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=ONSdigital/sdx-rabbit-python&amp;utm_campaign=Badge_Grade) [![codecov](https://codecov.io/gh/ONSdigital/sdc-rabbit-python/branch/master/graph/badge.svg)](https://codecov.io/gh/ONSdigital/sdc-rabbit-python) [![Codacy Badge](https://api.codacy.com/project/badge/Grade/043810e79dac47759cc661361a8af12b)](https://www.codacy.com/app/ONS/sdc-rabbit-python?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=ONSdigital/sdc-rabbit-python&amp;utm_campaign=Badge_Grade)
+[![Build Status](https://travis-ci.org/ONSdigital/sdc-rabbit-python.svg?branch=master)](https://travis-ci.org/ONSdigital/sdc-rabbit-python) 
+[![codecov](https://codecov.io/gh/ONSdigital/sdc-rabbit-python/branch/master/graph/badge.svg)](https://codecov.io/gh/ONSdigital/sdc-rabbit-python)
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/043810e79dac47759cc661361a8af12b)](https://www.codacy.com/app/ONS/sdc-rabbit-python?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=ONSdigital/sdc-rabbit-python&amp;utm_campaign=Badge_Grade)
 
 Common code for SDC Pika-based services that interact with RabbitMQ.
 


### PR DESCRIPTION
Url for travis badge was referencing codacy for some reason. Fixed to have the correct url as given by travis.